### PR TITLE
Use SO_REUSEADDR before binding to a port to avoid address used problems caused by TIME_WAIT

### DIFF
--- a/另一个VPS流量监控Surge面板.md
+++ b/另一个VPS流量监控Surge面板.md
@@ -139,9 +139,12 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         response_json = json.dumps(response_dict).encode('utf-8')
         self.wfile.write(response_json)
 
-with socketserver.ThreadingTCPServer(("", port), RequestHandler) as httpd:
+with socketserver.ThreadingTCPServer(("", port), RequestHandler, bind_and_activate=False) as httpd:
     try:
         print(f"Serving at port {port}")
+        httpd.allow_reuse_address = True
+        httpd.server_bind()
+        httpd.server_activate()
         httpd.serve_forever()
     except KeyboardInterrupt:
         print("KeyboardInterrupt is captured, program exited")


### PR DESCRIPTION
```
root@s20697 ~/scripts/servertraffic # ./venv/bin/python ./servertraffic.py 
Serving at port 7122
127.0.0.1 - - [06/Sep/2023 14:12:09] "GET / HTTP/1.1" 200 -
^CKeyboardInterrupt is captured, program exited
root@s20697 ~/scripts/servertraffic # ./venv/bin/python ./servertraffic.py 
Traceback (most recent call last):
  File "/root/scripts/servertraffic/./servertraffic.py", line 53, in <module>
    with socketserver.ThreadingTCPServer(("127.0.0.1", port), RequestHandler) as httpd:
  File "/usr/lib/python3.10/socketserver.py", line 452, in __init__
    self.server_bind()
  File "/usr/lib/python3.10/socketserver.py", line 466, in server_bind
    self.socket.bind(self.server_address)
OSError: [Errno 98] Address already in use
```